### PR TITLE
Update  VS2013Premium to use 2013 update 4 installer

### DIFF
--- a/VisualStudio2013Premium/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2013Premium/Tools/ChocolateyInstall.ps1
@@ -7,5 +7,5 @@ $env:chocolateyInstallArguments=""
 $settings = Initialize-VS-Settings $customArgs $adminFile
 $installerArgs = Get-VS-Installer-Args $settings.ProductKey
 
-Install-ChocolateyPackage 'VisualStudio2013Premium' 'exe' $installerArgs 'http://download.microsoft.com/download/D/B/D/DBDEE6BB-AF28-4C76-A5F8-710F610615F7/vs_premium_download.exe'
+Install-ChocolateyPackage 'VisualStudio2013Premium' 'exe' $installerArgs 'http://download.microsoft.com/download/0/D/3/0D316453-32A1-4042-A5B6-30B14A4C24AA/vs_premium_download.exe'
  

--- a/VisualStudio2013Premium/VisualStudio2013Premium.nuspec
+++ b/VisualStudio2013Premium/VisualStudio2013Premium.nuspec
@@ -2,15 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>VisualStudio2013Premium</id>
-        <version>12.0.21005.20141031</version>
-        <title>Visual Studio 2013 - Premium RTM</title>
+        <version>12.0.31101.00</version>
+        <title>Visual Studio 2013 - Premium RTM Update 4</title>
         <authors>Microsoft</authors>
         <owners>Matt Wrock</owners>
         <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
         <projectUrl>http://www.microsoft.com/visualstudio/eng/visual-studio-2013</projectUrl>
         <iconUrl>https://github.com/mwrock/Chocolatey-Packages/raw/master/VisualStudio2012Premium/vs.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>This silently installs Visual Studio 2013 Premium along with the Microsoft .Net 4.5.1 Framework SDK. 
+        <description>This silently installs Visual Studio 2013 Premium Update 4 along with the Microsoft .Net 4.5.1 Framework SDK. 
     ==================OPTIONAL FEATURES==================
     All Optional Features such as Blend, Sql Dev tools, Web dev tools, etc. are not installed by default, but you can provide install arguments to add them. Here is an example that includes the Web Tools and the Windows 8 Store App SDK:
 


### PR DESCRIPTION
This will update the VisualStudio2013Premium chocolatey package to use update 4 instead of update 2.