### PR TITLE
Updated Azure PowerShell to v 1.5.1 released on 28 June 2016.

### DIFF
--- a/WindowsAzurePowershell/Tools/ChocolateyInstall.ps1
+++ b/WindowsAzurePowershell/Tools/ChocolateyInstall.ps1
@@ -1,5 +1,5 @@
-$version = '1.4.0'
-$releaseName = "v$version-May2016"
+$version = '1.5.1'
+$releaseName = "v$version-June2016"
 
 if(!(Test-Path "HKLM:\Software\Microsoft\PowerShell\3")){
     Write-Host "Windows Azure Powershell requires Powershell version 3 or greater."

--- a/WindowsAzurePowershell/WindowsAzurePowershell.nuspec
+++ b/WindowsAzurePowershell/WindowsAzurePowershell.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.4.0</version>
+    <version>1.5.1</version>
     <authors>Microsoft</authors>
     <owners>Matt Wrock</owners>
     <iconUrl>https://1.gravatar.com/avatar/425be63bdaaeeffd26d0172ed2030198?d=https%3A%2F%2Fidenticons.github.com%2F732737be523b073de1e3f4cce6660d01.png&amp;r=x&amp;s=128</iconUrl>


### PR DESCRIPTION
@mwrock Followed the same template as the previous APosh updates. 