### PR TITLE
Update ChefDK to 1.2.22

### DIFF
--- a/chefdk/chefdk.nuspec
+++ b/chefdk/chefdk.nuspec
@@ -1,26 +1,22 @@
 ﻿<?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package 
+  xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>chefdk</id>
-    <version>1.1.16</version>
+    <version>1.2.22</version>
     <title>Chef Development Kit</title>
     <authors>Steven Murawski</authors>
     <owners>CHEF Software</owners>
     <licenseUrl>http://www.chef.io</licenseUrl>
     <projectUrl>https://github.com/chef/chef-dk</projectUrl>
+    <docsUrl>https://docs.chef.io/about_chefdk.html</docsUrl>
+    <mailingListUrl>https://discourse.chef.io</mailingListUrl>
+    <bugTrackerUrl>https://github.com/chef/chef-dk/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/chef/chef-dk</projectSourceUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The Chef Development Kit contains everything you need to start using Chef, along with the tools essential to managing the code that runs your business.
-
-ChefDK contains:
-
-* An early version of a brand new command-line tool, chef, that aims to streamline Chef workflow, starting with new generators.
-* The well-known cookbook dependency manager Berkshelf 5.1.
-* The Test Kitchen integration testing framework.
-* ChefSpec, which makes unit testing cookbooks a breeze.
-* Foodcritic, a linting tool for doing static code analysis on cookbooks.
-* All of the Chef tools you're already familiar with: Chef Client, Knife, Ohai and Chef Zero.</description>
+    <description>The Chef Development Kit contains everything you need to start using Chef, along with the tools essential to managing the code that runs your business.ChefDK contains:* An early version of a brand new command-line tool, chef, that aims to streamline Chef workflow, starting with new generators.* The well-known cookbook dependency manager Berkshelf 5.1.* The Test Kitchen integration testing framework.* ChefSpec, which makes unit testing cookbooks a breeze.* Foodcritic, a linting tool for doing static code analysis on cookbooks.* All of the Chef tools you're already familiar with: Chef Client, Knife, Ohai and Chef Zero.</description>
     <summary>The Chef Development Kit (ChefDK) brings the best-of-breed development tools built by the awesome Chef community to your workstation with just a few clicks. Download your package and start coding Chef in seconds.</summary>
-    <releaseNotes>[Changelog](https://github.com/chef/chef-dk/blob/v0.19.6/CHANGELOG.md)</releaseNotes>
+    <releaseNotes>[Changelog](https://github.com/chef/chef-dk/blob/v1.2.22/CHANGELOG.md)</releaseNotes>
     <copyright />
     <tags>chefdk chef-client chef test-kitchen chefspec foodcritic knife</tags>
   </metadata>

--- a/chefdk/tools/chocolateyinstall.ps1
+++ b/chefdk/tools/chocolateyinstall.ps1
@@ -1,16 +1,16 @@
 ﻿try {
-  $name = 'chefdk'
-  $version = '1.1.16'
-  $url = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
+    $name = 'chefdk'
+    $version = '1.2.22'
+    $url = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
 
-  $url64 = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
-  $installerType = 'MSI'
-  $silentArgs = "/qn /quiet /norestart"
-  $validExitCodes = @(0,3010)
+    $url64 = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
+    $installerType = 'MSI'
+    $silentArgs = "/qn /quiet /norestart"
+    $validExitCodes = @(0,3010)
 
-  $MD5Checksum = ''
-  Install-ChocolateyPackage "$name" "$installerType" "$silentArgs" "$url" "$url64"  -validExitCodes $validExitCodes -checksum $MD5Checksum -checksumtype 'md5'
+    $MD5Checksum = ''
+    Install-ChocolateyPackage "$name" "$installerType" "$silentArgs" "$url" "$url64"  -validExitCodes $validExitCodes -checksum $MD5Checksum -checksumtype 'md5'
 } catch {
-  Write-ChocolateyFailure $name $($_.Exception.Message)
-  throw
+    Write-ChocolateyFailure $name $($_.Exception.Message)
+throw
 }


### PR DESCRIPTION
I've already pushed a package up to the Chocolatey Gallery, but figured you might want to have the updated template. :)  I added some additional metadata that chocolatey now supports.

```
   <docsUrl>https://docs.chef.io/about_chefdk.html</docsUrl>
   <mailingListUrl>https://discourse.chef.io</mailingListUrl>
   <bugTrackerUrl>https://github.com/chef/chef-dk/issues</bugTrackerUrl>
   <projectSourceUrl>https://github.com/chef/chef-dk</projectSourceUrl>
```

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>