### PR TITLE
 Update ChefDK Chocolatey package to 2.2.1

### DIFF
--- a/chefdk/chefdk.nuspec
+++ b/chefdk/chefdk.nuspec
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>chefdk</id>
-    <version>2.1.11</version>
+    <version>2.2.1</version>
     <title>Chef Development Kit</title>
     <authors>Steven Murawski</authors>
     <owners>CHEF Software</owners>

--- a/chefdk/tools/chocolateyinstall.ps1
+++ b/chefdk/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿try {
     $name = 'chefdk'
-    $version = '2.1.11'
+    $version = '2.2.1'
     $url = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
 
     $url64 = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
@@ -8,7 +8,7 @@
     $silentArgs = "/qn /quiet /norestart"
     $validExitCodes = @(0,3010)
 
-    $SHA256Checksum = '9f805e9b6399d293209e27eaefe7b9ad0d36db3017e2cd419b27e41cb1d3092e'
+    $SHA256Checksum = 'd8761b0def610e65fdfbe0530715da613c4a4dff33da4c86ce493d7fab1fc086'
     Install-ChocolateyPackage "$name" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes $validExitCodes -checksum $SHA256Checksum -checksumtype 'sha256'
 } catch {
     Write-ChocolateyFailure $name $($_.Exception.Message)


### PR DESCRIPTION
Checked in my computer:

Chef Development Kit Version: 2.2.1
chef-client version: 13.3.42
delivery version: master (73ebb72a6c42b3d2ff5370c476be800fee7e5427)
berks version: 6.3.1
kitchen version: 1.17.0
inspec version: 1.35.1