### PR TITLE
Update chefdk to 2.3.1, distinguish 64 bit version

### DIFF
--- a/chefdk/chefdk.nuspec
+++ b/chefdk/chefdk.nuspec
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>chefdk</id>
-    <version>2.2.1</version>
+    <version>2.3.1</version>
     <title>Chef Development Kit</title>
     <authors>Steven Murawski</authors>
     <owners>CHEF Software</owners>

--- a/chefdk/tools/chocolateyinstall.ps1
+++ b/chefdk/tools/chocolateyinstall.ps1
@@ -1,15 +1,16 @@
 ﻿try {
     $name = 'chefdk'
-    $version = '2.2.1'
+    $version = '2.3.1'
     $url = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
 
-    $url64 = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x86.msi"
+    $url64 = "https://packages.chef.io/stable/windows/2012r2/chefdk-$version-1-x64.msi"
     $installerType = 'MSI'
     $silentArgs = "/qn /quiet /norestart"
     $validExitCodes = @(0,3010)
 
-    $SHA256Checksum = 'd8761b0def610e65fdfbe0530715da613c4a4dff33da4c86ce493d7fab1fc086'
-    Install-ChocolateyPackage "$name" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes $validExitCodes -checksum $SHA256Checksum -checksumtype 'sha256'
+    $SHA256Checksum = '243413a3911408763e44f487ab7ed1d7570e9a2195af5443be5f3cf9b358bc44'
+    $SHA256Checksum64 = 'f0a09d973eb23127f9bc38069d188186c2de3073c2dc6efcc6f95ea7ac0bf686'
+    Install-ChocolateyPackage "$name" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes $validExitCodes -checksum $SHA256Checksum -checksumtype 'sha256' -checksum64 $SHA256Checksum64 -checksumtype64 'sha256'
 } catch {
     Write-ChocolateyFailure $name $($_.Exception.Message)
 throw


### PR DESCRIPTION
This pull request udpates chefdk to 2.3.1 and adds 64 bit version download link and 64 bit checksum in installation script. @mwrock was there any specific reason why previous installation script only contained i386 installer url? Wondering if I did something not needed for 64 bit.