### PR TITLE
Adding "Source" package parameter

### DIFF
--- a/DotNet3.5/Tools/ChocolateyInstall.ps1
+++ b/DotNet3.5/Tools/ChocolateyInstall.ps1
@@ -1,11 +1,38 @@
+$ErrorActionPreference = 'Stop'
+
+# Capturing Package Parameters.
+$UserArguments = @{}
+if ($env:chocolateyPackageParameters) {
+   $match_pattern = "\/(?<option>([a-zA-Z]+)):(?<value>([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)|\/(?<option>([a-zA-Z]+))"
+   $option_name = 'option'
+   $value_name = 'value'
+
+   if ($env:chocolateyPackageParameters -match $match_pattern ){
+      $results = $env:chocolateyPackageParameters | Select-String $match_pattern -AllMatches
+      $results.matches | ForEach-Object {$UserArguments.Add(
+                           $_.Groups[$option_name].Value.Trim(),
+                           $_.Groups[$value_name].Value.Trim())
+                        }
+   } else { Throw 'Package Parameters were found but were invalid (REGEX Failure)' }
+} else { Write-Debug 'No Package Parameters Passed in' }
+
+$InstallArgs = ''
+if ($UserArguments.ContainsKey('Source')) {
+   if (test-path $UserArguments['Source']) {
+      $InstallArgs = "/Source:$UserArguments['Source']"
+   } else {
+      Throw "The source path '$($UserArguments['Source'])' is not available."
+   }
+}
+
 if(-not (test-path "hklm:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5")) {
   if((wmic os get caption | Out-String).Contains("Server")) {
       $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature /FeatureName:NetFx3ServerFeatures"
-      $statements = "cmd.exe $packageArgs"
+      $statements = "cmd.exe $packageArgs $InstallArgs"
       Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0, 1)
   }
   $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature /FeatureName:NetFx3"
-  $statements = "cmd.exe $packageArgs"
+  $statements = "cmd.exe $packageArgs $InstallArgs"
   Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0)
 }
 else {


### PR DESCRIPTION
This package fails on Win10 if the "microsoft-windows-netfx3-ondemand-package.CAB" file is not in the local SXS directory.

The "--installarguments" choco switch doesn't work for Start-ChocolateyProcessAsAdmin, so that option for passing on the "/Source" DISM switch isn't available.

I believe the change here will allow installing users to specify the location of the .CAB file if it is not default.

Thanks!