### PR TITLE
Switch to PowerShell utilities for installing .NET Framework 3.5 on Windows Server

### DIFF
--- a/DotNet3.5/Tools/ChocolateyInstall.ps1
+++ b/DotNet3.5/Tools/ChocolateyInstall.ps1
@@ -1,13 +1,19 @@
 if(-not (test-path "hklm:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5")) {
-  if((wmic os get caption | Out-String).Contains("Server")) {
-      $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature /FeatureName:NetFx3ServerFeatures"
-      $statements = "cmd.exe $packageArgs"
-      Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0, 1)
+  $osString = wmic os get caption | Out-String
+  if($osString.Contains("Server")) {
+    if($osString.Contains("2008")) {
+      Add-WindowsFeature -Name NET-Framework-Core
+	}
+	else {
+	  Install-WindowsFeature -Name NET-Framework-Core
+	}
   }
-  $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature /FeatureName:NetFx3"
-  $statements = "cmd.exe $packageArgs"
-  Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0)
+  else {
+    $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature /FeatureName:NetFx3"
+    $statements = "cmd.exe $packageArgs"
+    Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0)
+  }
 }
 else {
-     Write-Host "Microsoft .Net 3.5 Framework is already installed on your machine."
- } 
+  Write-Host "Microsoft .Net 3.5 Framework is already installed on your machine."
+}


### PR DESCRIPTION
This PR addresses https://github.com/mwrock/Chocolatey-Packages/issues/58.  It modifies the logic for installing on Windows Server instances and leaves the standard consumer Windows untouched.  I've verified that I can successfully install via WinRM on fresh AWS instances of the following:
- Windows Server 2008 R2
- Windows Server 2012 R2
- Windows Server 2016